### PR TITLE
Feat: Treasury interface to absorb slash(untested)

### DIFF
--- a/pallets/chocolate/src/mock.rs
+++ b/pallets/chocolate/src/mock.rs
@@ -1,6 +1,7 @@
 use crate as pallet_chocolate;
-use frame_support::parameter_types;
+use frame_support::{parameter_types, traits::OnUnbalanced};
 use frame_system as system;
+use pallet_balances::NegativeImbalance;
 use sp_core::H256;
 use sp_runtime::{
 	testing::Header,
@@ -73,15 +74,23 @@ impl pallet_balances::Config for Test {
 	type AccountStore = System;
 	type WeightInfo = ();
 }
-// our configs start here
+// temp treasury that has implements unbalanced which stores outer state that can be queried
+
+parameter_types! {
+	pub const Cap: u128 = 5 * 1;
+}
+// our configs start here	
 impl pallet_chocolate::Config for Test {
 	type Event = Event;
 	// no need to rope in collective pallet. we are enough
 	type ApprovedOrigin = frame_system::EnsureRoot<u64>;
 	// this is simply a pointer to the true implementor,and creator of the currency trait...the balances pallet
 	type Currency = Balances;
+	type TreasuryOutlet = ();
+	type RewardCap = Cap;
 }
 
+// construct a test that mocks treasury runtime but prints imbalance value instead
 // Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {
 	system::GenesisConfig::default().build_storage::<Test>().unwrap().into()

--- a/pallets/chocolate/src/tests.rs
+++ b/pallets/chocolate/src/tests.rs
@@ -4,17 +4,15 @@ use frame_support::{assert_noop, assert_ok};
 #[test]
 fn it_works_for_default_value() {
 	new_test_ext().execute_with(|| {
-		// Dispatch a signed extrinsic.
-		assert_ok!(ChocolateModule::do_something(Origin::signed(1), 42));
-		// Read pallet storage and assert an expected result.
-		assert_eq!(ChocolateModule::something(), Some(42));
+		// dispatch our test call
+
+		// check that the stored value is correct
+
 	});
 }
 
 #[test]
 fn correct_error_for_none_value() {
 	new_test_ext().execute_with(|| {
-		// Ensure the expected error is thrown when no value is present.
-		assert_noop!(ChocolateModule::cause_error(Origin::signed(1)), Error::<Test>::NoneValue);
 	});
 }

--- a/pallets/users/src/lib.rs
+++ b/pallets/users/src/lib.rs
@@ -53,6 +53,7 @@ pub mod pallet {
 		#[derive(Encode, Decode, Default, Clone)]
 		pub struct User {
 			pub rank_points: u32,
+			pub project_id: Option<u32>
 		}
 	}
 
@@ -65,7 +66,13 @@ pub mod pallet {
 		/// User already exists
 		UserAlreadyExists,
 	}
-
+	pub trait UserIO<T: Config> {
+		fn get_user_by_id(id: &T::AccountId) -> Option<User>;
+		fn check_owns_project(id: &T::AccountId) -> bool;
+		fn check_user_exists(id: &T::AccountId) -> bool;
+		fn set_user(id: &T::AccountId, user: User) -> DispatchResult;
+		fn update_user(id: &T::AccountId, user: User) -> DispatchResult;
+	}
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		// use base weight then add on any additional operations
@@ -76,10 +83,33 @@ pub mod pallet {
 			let who = ensure_signed(origin)?;
 
 			ensure!(!Users::<T>::contains_key(&who), Error::<T>::UserAlreadyExists);
-			<Users<T>>::insert(&who, User { rank_points: 0 });
+			<Users<T>>::insert(&who, User { rank_points: 0 , project_id: Option::None});
 
 			Self::deposit_event(Event::UserCreated(who));
 
+			Ok(())
+		}
+	}
+	impl<T: Config> UserIO<T> for Pallet<T>{
+		fn get_user_by_id(id: &T::AccountId) -> Option<User> {
+			Users::<T>::get(id)
+		}
+		fn check_owns_project(id: &T::AccountId) -> bool {
+			let user = Users::<T>::get(id).unwrap_or_default();
+			user.project_id.is_some()
+		}
+		fn check_user_exists(id: &T::AccountId) -> bool {
+			Users::<T>::contains_key(id)
+		}
+		/// Infallible. Simple inserts to storage. Your responsibility to ensure it doesn't already exist.
+		fn set_user(id: &T::AccountId, user: User) -> DispatchResult {
+			if Self::check_user_exists(id) { return Ok(()) }
+			<Users<T>>::insert(id, user);
+			Ok(())
+		}
+		fn update_user(id: &T::AccountId, user: User) -> DispatchResult {
+			if !Self::check_user_exists(id) { return Err(DispatchError::CannotLookup)  };
+			<Users<T>>::mutate(id, |u| *u = Some(user));
 			Ok(())
 		}
 	}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -331,6 +331,9 @@ impl pallet_sudo::Config for Runtime {
 	type Call = Call;
 }
 
+parameter_types! {
+	pub const RewardCap: Balance = 50 * CHOC; // define choc well.
+}
 /// Configure the pallet-chocolate in pallets/chocolate.
 impl pallet_chocolate::Config for Runtime {
 	type Event = Event;
@@ -340,6 +343,9 @@ impl pallet_chocolate::Config for Runtime {
 		pallet_collective::EnsureProportionAtLeast<_3, _5, AccountId, CouncilCollective>,
 	>;
 	type Currency = Balances;
+	type TreasuryOutlet = Treasury; 
+	type RewardCap = RewardCap;
+	
 }
 /// Configure the pallet-users in pallets/users.
 impl pallet_users::Config for Runtime {
@@ -441,10 +447,6 @@ impl pallet_treasury::Config for Runtime {
 	type SpendPeriod = SpendPeriod;
 	type Burn = Burn;
 	type BurnDestination = ();
-	// Initially implemented for Bounties pallet. Use this to make the treasury spend funds for reviews
-	// say if the treasury still has funds, reward the review, otherwise return their payments. Also use subaccounts for staking hehe?
-	// set it up so that if the user is not rewarded, we simply give them an opportunity to take it up with the treasury later.
-	// set up treasury in a way that we always have enough to cater for bonuses of everyone on the system in an interest manner.
 	type SpendFunds = ();
 	type WeightInfo = pallet_treasury::weights::SubstrateWeight<Runtime>;
 	type MaxApprovals = MaxApprovals;


### PR DESCRIPTION

**PR**
Note:
* The `TreasuryOutlet` config trait has not yet been tested to see if It actually takes in slashed tokens, nor has it been used yet. But it's useful as it's part of how we can interact with `pallet-treasury`'s exposed treasury.
*  `ProjectIO` and `UserIO` have been set up with somewhat skeletal abilities.
*  `ProjectIO` enables reserve of currency but falters a bit by introducing reward field to project which cannot be easily manipulated. I.e no concrete value but a snapshot.
*  `ProjectIO` has been shimmed on genesis config, so if the rewardCap config is also right, a simple test can be carried out to check balance and confirm it works
* `UserIO` simply allows us to talk to the users pallet. CRUD abilities. Nothing special yet

**Next up**
* I'll be looking into allowing `ProjectIO` and `UserIO` to talk to each other by modularising some shared things like the type of a `User`, the `UserIO` trait itself and so on into primitives crate.
* Expect trait defs extracted from runtime, chocolate module, and users next.
_Makes it much easier to provide context for what's next_.
* Extending these bases with more logic that doesn't quite require comms yet

**Issues**
* Genesis config is getting a tad messy, args spread?
* how to avoid hack of creating tokens out of thin air for config -- negative imbalance - treasury?.