### PR TITLE
Step1.5 modules primitives/balances/types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,6 +770,7 @@ name = "chocolate"
 version = "0.1.0"
 dependencies = [
  "chocolate-node-constants",
+ "chocolate-projects",
  "chocolate-runtime",
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -3970,6 +3971,7 @@ dependencies = [
  "frame-system",
  "pallet-balances",
  "pallet-treasury",
+ "pallet-users",
  "parity-scale-codec",
  "serde",
  "sp-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,6 +769,7 @@ dependencies = [
 name = "chocolate"
 version = "0.1.0"
 dependencies = [
+ "chocolate-node-constants",
  "chocolate-runtime",
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -804,9 +805,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "chocolate-node-constants"
+version = "0.1.0"
+
+[[package]]
+name = "chocolate-projects"
+version = "0.1.0"
+
+[[package]]
 name = "chocolate-runtime"
 version = "3.0.0-monthly-2021-08"
 dependencies = [
+ "chocolate-node-constants",
  "frame-benchmarking",
  "frame-executive",
  "frame-support",
@@ -843,6 +853,10 @@ dependencies = [
  "static_assertions",
  "substrate-wasm-builder",
 ]
+
+[[package]]
+name = "chocolate-users"
+version = "0.1.0"
 
 [[package]]
 name = "chrono"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,11 +806,30 @@ dependencies = [
 
 [[package]]
 name = "chocolate-node-constants"
-version = "0.1.0"
+version = "0.1.1"
+dependencies = [
+ "frame-system",
+ "parity-scale-codec",
+ "sp-core",
+ "sp-runtime",
+]
 
 [[package]]
 name = "chocolate-projects"
 version = "0.1.0"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "pallet-treasury",
+ "parity-scale-codec",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
 
 [[package]]
 name = "chocolate-runtime"
@@ -857,6 +876,17 @@ dependencies = [
 [[package]]
 name = "chocolate-users"
 version = "0.1.0"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
 
 [[package]]
 name = "chrono"
@@ -3933,6 +3963,8 @@ dependencies = [
 name = "pallet-chocolate"
 version = "0.1.0"
 dependencies = [
+ "chocolate-projects",
+ "chocolate-users",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -4129,6 +4161,7 @@ dependencies = [
 name = "pallet-users"
 version = "0.1.0"
 dependencies = [
+ "chocolate-users",
  "frame-benchmarking",
  "frame-support",
  "frame-system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     'node',
     'pallets/*',
     'runtime',
+    'primitives/*'
 ]
 [profile.release]
 panic = 'unwind'

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Built on Substrate.
 
 [![Substrate version](https://img.shields.io/badge/Substrate-3.0.0-brightgreen?logo=Parity%20Substrate)](https://substrate.dev/)
 [![Medium](https://img.shields.io/badge/Medium-Chocolate-brightgreen?logo=medium)](https://medium.com/)
+
 </div>
 
 ---
-
 
 # Substrate Node
 
@@ -188,6 +188,13 @@ A FRAME pallet is compromised of a number of blockchain primitives:
 - Errors: When a dispatchable fails, it returns an error.
 - Config: The `Config` configuration interface is used to define the types and parameters upon
   which a FRAME pallet depends.
+
+### primitives
+
+- This folder is customised for chocolate with packages that aren't part of runtime but shared across different pallets. Right now the package name is the same as the folder name for the packages inside primitives. This is simply for ease of use because it sort of gets confusing not knowing how packages and paths are different and trying to modularise things.
+- `chocolate-` is prefixed to the packages here for uniqueness, although we probably won't be publishing.
+
+<!-- Sounds good, or should we prioritise cleanness in package names? -->
 
 ### Run in Docker
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -174,6 +174,10 @@ version = '4.0.0-dev'
 git = 'https://github.com/paritytech/substrate.git'
 tag = 'monthly-2021-08'
 version = '4.0.0-dev'
+# added dep
+[dependencies.chocolate-projects]
+path = '../primitives/chocolate-projects'
+version = '0.1.0'
 
 [features]
 default = []

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -24,6 +24,10 @@ version = '3.0.0'
 path = '../runtime'
 version = '3.0.0-monthly-2021-08'
 
+[dependencies.chocolate-node-constants]
+path = '../primitives/chocolate-node-constants'
+version = '0.1.0'
+
 [dependencies]
 jsonrpc-core = '15.1.0'
 structopt = '0.3.8'

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -26,7 +26,7 @@ version = '3.0.0-monthly-2021-08'
 
 [dependencies.chocolate-node-constants]
 path = '../primitives/chocolate-node-constants'
-version = '0.1.0'
+version = '0.1.1'
 
 [dependencies]
 jsonrpc-core = '15.1.0'

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,4 +1,4 @@
-use chocolate_node_constants::currency::CHOC;
+use chocolate_node_constants::currency::HECTOCHOC;
 use chocolate_projects::{Reason, Status};
 use chocolate_runtime::{
 	AccountId, AuraConfig, Balance, BalancesConfig, ChocolateModuleConfig, CouncilConfig,
@@ -40,6 +40,8 @@ pub fn authority_keys_from_seed(s: &str) -> (AuraId, GrandpaId) {
 }
 
 // Generate Chain Properties for $CHOC token
+// Decimals -> 1 Balance unit = 10^-{Decimals}CHOC.
+// Taking example of this Instance -> 1 Balance unit = 10^-12 CHOC.
 pub fn chain_properties() -> Properties {
 	let mut properties = Properties::new();
 	properties.insert("tokenDecimals".into(), 12.into());
@@ -146,7 +148,7 @@ fn testnet_genesis(
 ) -> GenesisConfig {
 	let num_endowed_accounts = endowed_accounts.len();
 
-	const ENDOWMENT: Balance = 10_000_000 * CHOC;
+	const ENDOWMENT: Balance = 10_000_000 * HECTOCHOC;
 	const STASH: Balance = ENDOWMENT / 1000;
 	GenesisConfig {
 		system: SystemConfig {
@@ -155,14 +157,13 @@ fn testnet_genesis(
 			changes_trie_config: Default::default(),
 		},
 		balances: BalancesConfig {
-			// Configure endowed accounts with initial balance of 1 << 60.
-			// configure with initial balance of endowment instead to test - Each person gets 1B choc.
+			// Configure endowed accounts with initial balance of ENDOWMENT.
 			balances: endowed_accounts.iter().cloned().map(|k| (k, ENDOWMENT)).collect(),
 		},
 		elections: ElectionsConfig {
 			// configure all members to have an initial 'stash' backing, or elect them
 			// - These map to our default members of Council Collective - If not changed, council remains constant for n period
-			// Elect only half endowed accounts initially - Alice and Bob  - Backed with 1M each.
+			// Elect only half endowed accounts initially - Alice and Bob  - Backed with 1M each - Based on 12 Decimal choc.
 			members: endowed_accounts
 				.iter()
 				.take((num_endowed_accounts + 1) / 2)

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,8 +1,8 @@
 use chocolate_node_constants::currency::CHOC;
+use chocolate_projects::{Reason, Status};
 use chocolate_runtime::{
-	pallet_chocolate::{Reason, Status},
 	AccountId, AuraConfig, Balance, BalancesConfig, ChocolateModuleConfig, CouncilConfig,
-	ElectionsConfig, GenesisConfig, GrandpaConfig, Signature, SudoConfig, SystemConfig, 
+	ElectionsConfig, GenesisConfig, GrandpaConfig, Signature, SudoConfig, SystemConfig,
 	WASM_BINARY,
 };
 use sc_service::{ChainType, Properties};

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,8 +1,8 @@
-// The extra import : CHOC could be moved to currency part of constants.
+use chocolate_node_constants::currency::CHOC;
 use chocolate_runtime::{
 	pallet_chocolate::{Reason, Status},
 	AccountId, AuraConfig, Balance, BalancesConfig, ChocolateModuleConfig, CouncilConfig,
-	ElectionsConfig, GenesisConfig, GrandpaConfig, Signature, SudoConfig, SystemConfig, CHOC,
+	ElectionsConfig, GenesisConfig, GrandpaConfig, Signature, SudoConfig, SystemConfig, 
 	WASM_BINARY,
 };
 use sc_service::{ChainType, Properties};

--- a/pallets/chocolate/Cargo.toml
+++ b/pallets/chocolate/Cargo.toml
@@ -83,7 +83,16 @@ version = '4.0.0-dev'
 version = "1.0.126"
 optional = true
 features = ['derive']
-
+# # added dep
+[dependencies.chocolate-users]
+path = '../../primitives/chocolate-users'
+default-features = false
+version = '0.1.0'
+# # added dep
+[dependencies.chocolate-projects]
+path = '../../primitives/chocolate-projects'
+default-features = false
+version = '0.1.0'
 
 [features]
 default = ['std']
@@ -97,5 +106,8 @@ std = [
     'pallet-treasury/std',
     'pallet-balances/std',
     'frame-benchmarking/std',
+    # added
+    'chocolate-users/std',
+    'chocolate-projects/std',
 ]
 try-runtime = ['frame-support/try-runtime']

--- a/pallets/chocolate/Cargo.toml
+++ b/pallets/chocolate/Cargo.toml
@@ -93,6 +93,11 @@ version = '0.1.0'
 path = '../../primitives/chocolate-projects'
 default-features = false
 version = '0.1.0'
+# # added dep - is this tight coupling??
+[dependencies.pallet-users]
+default-features = false
+path = '../users'
+version = '0.1.0'
 
 [features]
 default = ['std']
@@ -109,5 +114,6 @@ std = [
     # added
     'chocolate-users/std',
     'chocolate-projects/std',
+    'pallet-users/std',
 ]
 try-runtime = ['frame-support/try-runtime']

--- a/pallets/chocolate/src/benchmarking.rs
+++ b/pallets/chocolate/src/benchmarking.rs
@@ -6,15 +6,15 @@ use super::*;
 use crate::Pallet as Chocolate;
 use frame_benchmarking::{benchmarks, impl_benchmark_test_suite, whitelisted_caller};
 use frame_system::RawOrigin;
-
-benchmarks! {
-	do_something {
-		let s in 0 .. 100;
-		let caller: T::AccountId = whitelisted_caller();
-	}: _(RawOrigin::Signed(caller), s)
-	verify {
-		assert_eq!(Something::<T>::get(), Some(s));
-	}
+// calls do_something multiple times 0..100 inputs verifying it got stored each time
+benchmarks! { // comment for now, do_something is gone, but it's legacy remains
+	// do_something {
+		// let s in 0 .. 100;
+		// let caller: T::AccountId = whitelisted_caller();
+	// }: _(RawOrigin::Signed(caller), s)
+	// verify {
+		// assert_eq!(Something::<T>::get(), Some(s));
+	// }
 }
 
 impl_benchmark_test_suite!(Chocolate, crate::mock::new_test_ext(), crate::mock::Test);

--- a/pallets/chocolate/src/lib.rs
+++ b/pallets/chocolate/src/lib.rs
@@ -20,6 +20,8 @@ pub mod constants;
 #[frame_support::pallet]
 pub mod pallet {
 	use crate::constants;
+	use chocolate_projects::*;
+	use chocolate_users::UserIO;
 	use frame_support::{
 		dispatch::DispatchResult,
 		pallet_prelude::*,
@@ -43,107 +45,24 @@ pub mod pallet {
 		type Currency: Currency<Self::AccountId> + ReservableCurrency<Self::AccountId>;
 		/// * Treasury outlet: A type with bounds to move slashed funds to the treasury.
 		type TreasuryOutlet: OnUnbalanced<NegativeImbalanceOf<Self>>;
+		/// This is it! The user pallet. A type with bounds to access the user module.
+		type UsersOutlet: UserIO<Self>;
 		/// * Reward Cap: Max reward projects can place on themselves
 		#[pallet::constant]
 		type RewardCap: Get<BalanceOf<Self>>;
 	}
-	pub type NegativeImbalanceOf<T> =
-		<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::NegativeImbalance;
-	/// type alias for text
-	pub type TextAl = Vec<u8>;
-	/// A simple u32
-	pub type ProjectID = u32;
-	/// Index for reviews , use to link to project
-	pub type ReviewID = u64;
+	pub type NegativeImbalanceOf<T> = <<T as Config>::Currency as Currency<
+		<T as frame_system::Config>::AccountId,
+	>>::NegativeImbalance;
+
 	/// type alias for review - this is the base struct, like the 2nd part of Balancesof
 	pub type ReviewAl<T> = Review<<T as frame_system::Config>::AccountId>;
 	/// type alias for project
-	pub type ProjectAl<T> = Project<<T as frame_system::Config>::AccountId,BalanceOf<T>>;
+	pub type ProjectAl<T> = Project<<T as frame_system::Config>::AccountId, BalanceOf<T>>;
 	/// Type alias for balance, binding T::Currency to Currency::AccountId and then extracting from that Balance. Accessible via T::BalanceOf. T is frame_System.
 	type BalanceOf<T> =
 		<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 
-	use codec::{Decode, Encode};
-	#[derive(Encode, Decode, Default, Clone, PartialEq)]
-	#[cfg_attr(feature = "std", derive(Debug))]
-	pub struct Review<UserID> {
-		proposal_status: ProposalStatus,
-		user_id: UserID,
-		content: Vec<u8>,
-		project_id: ProjectID,
-	}
-
-	/// The metadata of a project.
-	type MetaData = Vec<u8>;
-
-	#[cfg(feature = "std")]
-	pub use serde::{Deserialize, Serialize};
-
-	/// The status of the proposal
-	#[derive(Encode, Decode, Clone, PartialEq)]
-	#[cfg_attr(feature = "std", derive(Debug))]
-	#[cfg_attr(feature = "std", derive(Deserialize, Serialize))]
-	pub enum Status {
-		///Proposal created
-		Proposed,
-		/// Proposal accepted
-		Accepted,
-		/// Proposal rejected
-		Rejected,
-	}
-	/// Reason for the current status - Required for rejected proposal.
-	#[derive(Encode, Decode, Clone, PartialEq)]
-	#[cfg_attr(feature = "std", derive(Debug))]
-	#[cfg_attr(feature = "std", derive(Deserialize, Serialize))]
-	pub enum Reason {
-		/// Custom reason to encapsulate further things like marketCap and other details
-		Other(Vec<u8>),
-		/// Negative lenient - base conditions for project missing or review lacking detail
-		InsufficientMetaData,
-		/// Negative harsh, project or review is malicious
-		Malicious,
-		/// Positive neutral, covers rank up to accepted.
-		PassedRequirements,
-	}
-	/// The status of a proposal sent to the council from here.
-	#[derive(Encode, Decode, Default, Clone, PartialEq)]
-	#[cfg_attr(feature = "std", derive(Debug))]
-	pub struct ProposalStatus {
-		status: Status,
-		reason: Reason,
-	}
-	/// Default status - storage req
-	impl Default for Status {
-		fn default() -> Self {
-			Status::Proposed
-		}
-	}
-	/// Default reason - storage req
-	impl Default for Reason {
-		fn default() -> Self {
-			Reason::PassedRequirements
-		}
-	}
-	/// The project structure.
-	#[derive(Encode, Decode, Default, Clone, PartialEq)]
-	#[cfg_attr(feature = "std", derive(Debug))]
-	pub struct Project<UserID,Balance> {
-		/// The owner of the project
-		owner_id: UserID,
-		/// A list of the project's reviewers for validation
-		reviewers: Option<Vec<UserID>>,
-		/// A list of the project's reviews - Vec
-		reviews: Option<Vec<ReviewID>>,
-		/// A bool that allows for simple allocation of the unique chocolate badge. NFT??
-		badge: Option<bool>,
-		/// Project metadata
-		metadata: MetaData,
-		/// the status of the project's proposal in the council.
-		proposal_status: ProposalStatus,
-		/// A reward value for the project
-		reward: Balance,
-	}
-// ------------------------------------------------------------^edit
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
 	pub struct Pallet<T>(_);
@@ -192,7 +111,7 @@ pub mod pallet {
 		StorageOverflow,
 		/// Project owners cannot review their projects
 		OwnerReviewedProject,
-		/// Insufficient funds for rewarding reviewers Do seek a bounty from the treasury. 
+		/// Insufficient funds for rewarding reviewers Do seek a bounty from the treasury.
 		InsufficientBalance,
 	}
 	// ----------------------------- ^edit
@@ -207,23 +126,21 @@ pub mod pallet {
 			let n_index = <ProjectIndex<T>>::get().unwrap_or_default();
 			let new = n_index.checked_add(1).ok_or(Error::<T>::StorageOverflow)?;
 			// check if project already exists from userIO. if so, Err(you already have one!).
-			
+
 			// if balance available, reserve reward, else direct to treasury for bounty.
-			let mut project = Project {
-					owner_id: who.clone(),
-					reviewers: Option::None,
-					reviews: Option::None,
-					badge: Option::None,
-					metadata: project_meta.clone(),
-					proposal_status: Default::default(),
-					reward: Default::default()
-				};
-			ProjectIO::<T>::reserve_reward(&mut project)?;	
-			// STORAGE MUTATIONS
-			<Projects<T>>::insert(
-				n_index.clone(),
-				project
+			let mut project = ProjectAl::<T>::new(
+				who.clone(),
+				Option::None,
+				Option::None,
+				Option::None,
+				project_meta.clone(),
+				Default::default(),
+				Default::default(),
 			);
+
+			Pallet::<T>::reserve_reward(&mut project)?;
+			// STORAGE MUTATIONS
+			<Projects<T>>::insert(n_index.clone(), project);
 			<ProjectIndex<T>>::put(new);
 			Self::deposit_event(Event::ProjectCreated(who, project_meta));
 			Ok(())
@@ -273,33 +190,28 @@ pub mod pallet {
 			// call its ensure origin
 			let _who = T::ApprovedOrigin::ensure_origin(origin)?;
 			// then check subsume our balance - ToDo
-			
+
 			Self::deposit_event(Event::Minted(x.clone()));
 			Ok(())
 		}
+	}
 
-	}
-	/// A trait that allows project to:
-	/// - reserve some token for rewarding its reviewers.
-	pub trait ProjectIO<T:Config>{
-		fn can_reward(&self)->bool;
-		fn reserve_reward(&mut self) -> DispatchResult;
-	}
-	impl<T:Config> ProjectIO<T> for ProjectAl<T>{
-		fn can_reward(&self)->bool{
-			T::Currency::can_reserve(&self.owner_id, T::RewardCap::get())
+	impl<T: Config> ProjectIO<T> for Pallet<T> {
+		type UserID = T::AccountId;
+		type Balance = BalanceOf<T>;
+		fn can_reward(project_struct: &ProjectAl<T>) -> bool {
+			T::Currency::can_reserve(&project_struct.owner_id, T::RewardCap::get())
 		}
-		fn reserve_reward(&mut self) -> DispatchResult{
-			ensure!(ProjectIO::<T>::can_reward(self),Error::<T>::InsufficientBalance);
-			T::Currency::reserve(&self.owner_id, T::RewardCap::get())?;
-			self.reward = T::RewardCap::get();
+		fn reserve_reward(project_struct: &mut ProjectAl<T>) -> DispatchResult {
+			ensure!(Pallet::<T>::can_reward(&project_struct), Error::<T>::InsufficientBalance);
+			T::Currency::reserve(&project_struct.owner_id, T::RewardCap::get())?;
+			project_struct.reward = T::RewardCap::get();
 			Ok(())
 		}
 	}
-	
+
 	/// A separate impl pallet<T> for custom functions that aren't extrinsics
 	impl<T: Config> Pallet<T> {
-		
 		/// Create a project from required data - only for genesis
 		pub fn initialize_projects(
 			this_owner_id: T::AccountId,
@@ -309,24 +221,24 @@ pub mod pallet {
 			this_status: Status,
 			this_reason: Reason,
 		) -> ProjectAl<T> {
-			let mut returnable = Project {
-				owner_id: this_owner_id.clone(),
-				reviewers: Option::Some(this_reviewers),
-				reviews: Option::Some(this_revs),
-				badge: Option::None,
-				metadata: this_meta,
-				proposal_status: ProposalStatus { status: this_status, reason: this_reason },
-				reward: Default::default(),
-			};
-			let res= ProjectIO::<T>::reserve_reward(&mut returnable);
-			if !res.is_ok(){
+			let mut returnable = ProjectAl::<T>::new(
+				this_owner_id.clone(),
+				Option::Some(this_reviewers),
+				Option::Some(this_revs),
+				Option::None,
+				this_meta,
+				ProposalStatus { status: this_status, reason: this_reason },
+				Default::default(),
+			);
+			let res = Pallet::<T>::reserve_reward(&mut returnable);
+			if !res.is_ok() {
 				// temporary hack to ensure we have enough. Figure out a way of directly issuing from the treasury without spend some funds and co. for this genesis. And give the treasury some funds!
-                let imbalance =T::Currency::issue( T::RewardCap::get());
-                let imbalance2 =T::Currency::issue( T::RewardCap::get());
+				let imbalance = T::Currency::issue(T::RewardCap::get());
+				let imbalance2 = T::Currency::issue(T::RewardCap::get());
 
 				T::Currency::resolve_creating(&this_owner_id, imbalance);
 				T::Currency::resolve_creating(&this_owner_id, imbalance2);
-				let _= ProjectIO::<T>::reserve_reward(&mut returnable);
+				let _ = Pallet::<T>::reserve_reward(&mut returnable);
 			}
 
 			returnable

--- a/pallets/chocolate/src/mock.rs
+++ b/pallets/chocolate/src/mock.rs
@@ -2,6 +2,7 @@ use crate as pallet_chocolate;
 use frame_support::{parameter_types, traits::OnUnbalanced};
 use frame_system as system;
 use pallet_balances::NegativeImbalance;
+use pallet_users;
 use sp_core::H256;
 use sp_runtime::{
 	testing::Header,
@@ -22,6 +23,7 @@ frame_support::construct_runtime!(
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		ChocolateModule: pallet_chocolate::{Pallet, Call, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+		UsersModule: pallet_users::{Pallet, Call, Storage, Event<T>},
 	}
 );
 
@@ -74,12 +76,17 @@ impl pallet_balances::Config for Test {
 	type AccountStore = System;
 	type WeightInfo = ();
 }
-// temp treasury that has implements unbalanced which stores outer state that can be queried
+// ToDo! temp treasury that has implements unbalanced which stores outer state that can be queried
 
+// This is a mock runtime hence we can't avoid importing users and other deps.
+/// Configure the pallet-users for UserIO trait
+impl pallet_users::Config for Test {
+	type Event = Event;
+}
 parameter_types! {
 	pub const Cap: u128 = 5 * 1;
 }
-// our configs start here	
+// our configs start here
 impl pallet_chocolate::Config for Test {
 	type Event = Event;
 	// no need to rope in collective pallet. we are enough
@@ -88,6 +95,7 @@ impl pallet_chocolate::Config for Test {
 	type Currency = Balances;
 	type TreasuryOutlet = ();
 	type RewardCap = Cap;
+	type UsersOutlet = UsersModule;
 }
 
 // construct a test that mocks treasury runtime but prints imbalance value instead

--- a/pallets/chocolate/src/mock.rs
+++ b/pallets/chocolate/src/mock.rs
@@ -1,6 +1,7 @@
 use crate as pallet_chocolate;
-use frame_support::parameter_types;
+use frame_support::{parameter_types, traits::OnUnbalanced};
 use frame_system as system;
+use pallet_balances::NegativeImbalance;
 use sp_core::H256;
 use sp_runtime::{
 	testing::Header,
@@ -73,15 +74,23 @@ impl pallet_balances::Config for Test {
 	type AccountStore = System;
 	type WeightInfo = ();
 }
-// our configs start here
+// temp treasury that has implements unbalanced which stores outer state that can be queried
+
+parameter_types! {
+	pub const Cap: u128 = 5 * 1;
+}
+// our configs start here	
 impl pallet_chocolate::Config for Test {
 	type Event = Event;
 	// no need to rope in collective pallet. we are enough
 	type ApprovedOrigin = frame_system::EnsureRoot<u64>;
 	// this is simply a pointer to the true implementor,and creator of the currency trait...the balances pallet
 	type Currency = Balances;
+	type TreasuryOutlet = ();
+	type RewardCap = Cap;
 }
 
+// construct a test that mocks treasury runtime but prints imbalance value instead
 // Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {
 	system::GenesisConfig::default().build_storage::<Test>().unwrap().into()

--- a/pallets/chocolate/src/tests.rs
+++ b/pallets/chocolate/src/tests.rs
@@ -4,17 +4,15 @@ use frame_support::{assert_noop, assert_ok};
 #[test]
 fn it_works_for_default_value() {
 	new_test_ext().execute_with(|| {
-		// Dispatch a signed extrinsic.
-		assert_ok!(ChocolateModule::do_something(Origin::signed(1), 42));
-		// Read pallet storage and assert an expected result.
-		assert_eq!(ChocolateModule::something(), Some(42));
+		// dispatch our test call
+
+		// check that the stored value is correct
+
 	});
 }
 
 #[test]
 fn correct_error_for_none_value() {
 	new_test_ext().execute_with(|| {
-		// Ensure the expected error is thrown when no value is present.
-		assert_noop!(ChocolateModule::cause_error(Origin::signed(1)), Error::<Test>::NoneValue);
 	});
 }

--- a/pallets/users/Cargo.toml
+++ b/pallets/users/Cargo.toml
@@ -64,6 +64,11 @@ default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 tag = 'monthly-2021-08'
 version = '4.0.0-dev'
+# added dep
+[dependencies.chocolate-users]
+path = '../../primitives/chocolate-users'
+default-features = false
+version = '0.1.0'
 
 [features]
 default = ['std']
@@ -74,5 +79,7 @@ std = [
     'frame-support/std',
     'frame-system/std',
     'frame-benchmarking/std',
+     # added
+    'chocolate-users/std',
 ]
 try-runtime = ['frame-support/try-runtime']

--- a/pallets/users/src/lib.rs
+++ b/pallets/users/src/lib.rs
@@ -78,6 +78,7 @@ pub mod pallet {
 			let user = self::Users::<T>::get(id).unwrap_or_default();
 			user.project_id.is_some()
 		}
+		/// Allows us to check if the user even exists before calling get by id.
 		fn check_user_exists(id: &T::AccountId) -> bool {
 			self::Users::<T>::contains_key(id)
 		}

--- a/pallets/users/src/lib.rs
+++ b/pallets/users/src/lib.rs
@@ -53,6 +53,7 @@ pub mod pallet {
 		#[derive(Encode, Decode, Default, Clone)]
 		pub struct User {
 			pub rank_points: u32,
+			pub project_id: Option<u32>
 		}
 	}
 
@@ -65,7 +66,13 @@ pub mod pallet {
 		/// User already exists
 		UserAlreadyExists,
 	}
-
+	pub trait UserIO<T: Config> {
+		fn get_user_by_id(id: &T::AccountId) -> Option<User>;
+		fn check_owns_project(id: &T::AccountId) -> bool;
+		fn check_user_exists(id: &T::AccountId) -> bool;
+		fn set_user(id: &T::AccountId, user: User) -> DispatchResult;
+		fn update_user(id: &T::AccountId, user: User) -> DispatchResult;
+	}
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		// use base weight then add on any additional operations
@@ -76,10 +83,33 @@ pub mod pallet {
 			let who = ensure_signed(origin)?;
 
 			ensure!(!Users::<T>::contains_key(&who), Error::<T>::UserAlreadyExists);
-			<Users<T>>::insert(&who, User { rank_points: 0 });
+			<Users<T>>::insert(&who, User { rank_points: 0 , project_id: Option::None});
 
 			Self::deposit_event(Event::UserCreated(who));
 
+			Ok(())
+		}
+	}
+	impl<T: Config> UserIO<T> for Pallet<T>{
+		fn get_user_by_id(id: &T::AccountId) -> Option<User> {
+			Users::<T>::get(id)
+		}
+		fn check_owns_project(id: &T::AccountId) -> bool {
+			let user = Users::<T>::get(id).unwrap_or_default();
+			user.project_id.is_some()
+		}
+		fn check_user_exists(id: &T::AccountId) -> bool {
+			Users::<T>::contains_key(id)
+		}
+		/// Infallible. Simple inserts to storage. Your responsibility to ensure it doesn't already exist.
+		fn set_user(id: &T::AccountId, user: User) -> DispatchResult {
+			if Self::check_user_exists(id) { return Ok(()) }
+			<Users<T>>::insert(id, user);
+			Ok(())
+		}
+		fn update_user(id: &T::AccountId, user: User) -> DispatchResult {
+			if !Self::check_user_exists(id) { return Err(DispatchError::CannotLookup)  };
+			<Users<T>>::mutate(id, |u| *u = Some(user));
 			Ok(())
 		}
 	}

--- a/pallets/users/src/lib.rs
+++ b/pallets/users/src/lib.rs
@@ -20,10 +20,9 @@ pub use pallet::*;
 
 #[frame_support::pallet]
 pub mod pallet {
+	use chocolate_users::*;
 	use frame_support::{dispatch::DispatchResult, pallet_prelude::*};
 	use frame_system::pallet_prelude::*;
-	use sp_std::vec::Vec;
-
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
@@ -42,20 +41,8 @@ pub mod pallet {
 	}
 
 	#[pallet::storage]
-	// users store
+	/// users store
 	pub type Users<T: Config> = StorageMap<_, Blake2_128Concat, T::AccountId, User>;
-
-	use v1::User;
-	pub mod v1 {
-		use codec::{Decode, Encode};
-		use sp_std::vec::Vec;
-
-		#[derive(Encode, Decode, Default, Clone)]
-		pub struct User {
-			pub rank_points: u32,
-			pub project_id: Option<u32>
-		}
-	}
 
 	#[pallet::error]
 	pub enum Error<T> {
@@ -66,49 +53,46 @@ pub mod pallet {
 		/// User already exists
 		UserAlreadyExists,
 	}
-	pub trait UserIO<T: Config> {
-		fn get_user_by_id(id: &T::AccountId) -> Option<User>;
-		fn check_owns_project(id: &T::AccountId) -> bool;
-		fn check_user_exists(id: &T::AccountId) -> bool;
-		fn set_user(id: &T::AccountId, user: User) -> DispatchResult;
-		fn update_user(id: &T::AccountId, user: User) -> DispatchResult;
-	}
+
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		// use base weight then add on any additional operations
-		// strings are u8 arrays. utf-8
 		/// Signed transaction to create user
 		#[pallet::weight(0 + T::DbWeight::get().writes(1))]
 		pub fn make_user(origin: OriginFor<T>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 
 			ensure!(!Users::<T>::contains_key(&who), Error::<T>::UserAlreadyExists);
-			<Users<T>>::insert(&who, User { rank_points: 0 , project_id: Option::None});
+			<Users<T>>::insert(&who, User { rank_points: 0, project_id: Option::None });
 
 			Self::deposit_event(Event::UserCreated(who));
 
 			Ok(())
 		}
 	}
-	impl<T: Config> UserIO<T> for Pallet<T>{
+	impl<T: Config> UserIO<T> for Pallet<T> {
 		fn get_user_by_id(id: &T::AccountId) -> Option<User> {
-			Users::<T>::get(id)
+			self::Users::<T>::get(id)
 		}
 		fn check_owns_project(id: &T::AccountId) -> bool {
-			let user = Users::<T>::get(id).unwrap_or_default();
+			let user = self::Users::<T>::get(id).unwrap_or_default();
 			user.project_id.is_some()
 		}
 		fn check_user_exists(id: &T::AccountId) -> bool {
-			Users::<T>::contains_key(id)
+			self::Users::<T>::contains_key(id)
 		}
 		/// Infallible. Simple inserts to storage. Your responsibility to ensure it doesn't already exist.
 		fn set_user(id: &T::AccountId, user: User) -> DispatchResult {
-			if Self::check_user_exists(id) { return Ok(()) }
+			if Self::check_user_exists(id) {
+				return Ok(()); // Should it err instead??
+			}
 			<Users<T>>::insert(id, user);
 			Ok(())
 		}
 		fn update_user(id: &T::AccountId, user: User) -> DispatchResult {
-			if !Self::check_user_exists(id) { return Err(DispatchError::CannotLookup)  };
+			if !Self::check_user_exists(id) {
+				return Err(DispatchError::CannotLookup);
+			};
 			<Users<T>>::mutate(id, |u| *u = Some(user));
 			Ok(())
 		}

--- a/primitives/chocolate-node-constants/Cargo.toml
+++ b/primitives/chocolate-node-constants/Cargo.toml
@@ -1,9 +1,42 @@
 [package]
 name = "chocolate-node-constants"
-version = "0.1.0"
 edition = "2021"
 description = "Some constants for the chocolate node with helpful methods"
-
+version= "0.1.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
 
-[dependencies]
+[dependencies.codec]
+default-features = false
+features = ['derive']
+package = 'parity-scale-codec'
+version = '2.0.0'
+
+[dependencies.frame-system]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'monthly-2021-08'
+version = '4.0.0-dev'
+
+[dependencies.sp-core]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'monthly-2021-08'
+version = '4.0.0-dev'
+
+[dependencies.sp-runtime]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'monthly-2021-08'
+version = '4.0.0-dev'
+
+[features]
+default = ["std"]
+std = [
+	"codec/std",
+	"frame-system/std",
+	"sp-core/std",
+	"sp-runtime/std",
+]
+

--- a/primitives/chocolate-node-constants/Cargo.toml
+++ b/primitives/chocolate-node-constants/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "chocolate-node-constants"
+version = "0.1.0"
+edition = "2021"
+description = "Some constants for the chocolate node with helpful methods"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/primitives/chocolate-node-constants/src/currency.rs
+++ b/primitives/chocolate-node-constants/src/currency.rs
@@ -1,9 +1,24 @@
 use crate::Balance;
-
-// The balance type is general as used in our chain i.e based on 10^-12.
+/// Base Unit for currency
+/// ====================================
+/// Sinec the Max Number we can use in runtime is u32
+///
+/// We prepare these consts by Balance conversion/prefixing Based on SI units
+/// Hence, the units of balance are:
+///
+/// 1 Balance - pico :10^-12
+/// 1_000 Balance - nano :10^-9
+/// 1_000_000 Balance - micro :10^-6
+/// 1_000_000_000 Balance - milli :10^-3
+/// 1_000_000_000_000 Balance - one :10^0
+/// and so on. Hence, we define a base pico choc as 1Balance, and further chocs as their powers of this.
+///
+///
+/// The balance type is general as used in our chain i.e based on 10^-12. Or pico.
+pub const PICOCHOC: Balance = 1; //10^-12
 /// 10^9
-pub const MILLICENTICHOC: Balance = 1_000_000_000;
+pub const MILLICHOC: Balance = 1_000_000_000 * PICOCHOC; // Equiv to 10^(-12+9) or milli
 /// 10^12
-pub const CENTICHOC: Balance = 1_000 * MILLICENTICHOC;
+pub const CHOC: Balance = 1_000 * MILLICHOC; // actually equiv to 1
 /// 10^(12+2) === 100.{000}*4
-pub const CHOC: Balance = 100 * CENTICHOC;
+pub const HECTOCHOC: Balance = 100 * CHOC; // actually 100. Now we start.

--- a/primitives/chocolate-node-constants/src/currency.rs
+++ b/primitives/chocolate-node-constants/src/currency.rs
@@ -1,0 +1,9 @@
+use crate::Balance;
+
+// The balance type is general as used in our chain i.e based on 10^-12.
+/// 10^9
+pub const MILLICENTICHOC: Balance = 1_000_000_000;
+/// 10^12
+pub const CENTICHOC: Balance = 1_000 * MILLICENTICHOC;
+/// 10^(12+2) === 100.{000}*4
+pub const CHOC: Balance = 100 * CENTICHOC;

--- a/primitives/chocolate-node-constants/src/lib.rs
+++ b/primitives/chocolate-node-constants/src/lib.rs
@@ -1,4 +1,15 @@
-#[cfg(test)]
-mod tests;
+//! A collection of primitives used throughout chocolate
+
+#![warn(missing_docs)]
+#![cfg_attr(not(feature = "std"), no_std)]
+/// Module of constants describing the units of the fungible token system used.
 pub mod currency;
+/// Module of constants describing the units of time used on-chain for ease.
 pub mod time;
+pub use crate::currency::*;
+pub use crate::time::*;
+
+/// Balance of an account.
+pub type Balance = u128;
+/// An index to a block.
+pub type BlockNumber = u32;

--- a/primitives/chocolate-node-constants/src/lib.rs
+++ b/primitives/chocolate-node-constants/src/lib.rs
@@ -1,0 +1,4 @@
+#[cfg(test)]
+mod tests;
+pub mod currency;
+pub mod time;

--- a/primitives/chocolate-node-constants/src/tests.rs
+++ b/primitives/chocolate-node-constants/src/tests.rs
@@ -1,0 +1,5 @@
+#[test]
+fn it_works() {
+	let result = 2 + 2;
+	assert_eq!(result, 4);
+}

--- a/primitives/chocolate-node-constants/src/tests.rs
+++ b/primitives/chocolate-node-constants/src/tests.rs
@@ -1,5 +1,0 @@
-#[test]
-fn it_works() {
-	let result = 2 + 2;
-	assert_eq!(result, 4);
-}

--- a/primitives/chocolate-node-constants/src/time.rs
+++ b/primitives/chocolate-node-constants/src/time.rs
@@ -1,0 +1,21 @@
+use crate::BlockNumber;
+/// This determines the average expected block time that we are targeting.
+/// Blocks will be produced at a minimum duration defined by `SLOT_DURATION`.
+/// `SLOT_DURATION` is picked up by `pallet_timestamp` which is in turn picked
+/// up by `pallet_aura` to implement `fn slot_duration()`.
+///
+/// Change this to adjust the block time.
+pub const MILLISECS_PER_BLOCK: u64 = 6000;
+
+// NOTE: Currently it is not possible to change the slot duration after the chain has started.
+//       Attempting to do so will brick block production.
+/// Equivalent to the milliseconds per block.
+/// Time is measured by number of blocks for consensus.
+pub const SLOT_DURATION: u64 = MILLISECS_PER_BLOCK;
+/// An approximate minute
+pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);
+/// An approximate Hour in block time
+pub const HOURS: BlockNumber = MINUTES * 60;
+/// An approximate hour in block time
+pub const DAYS: BlockNumber = HOURS * 24;
+// Interesting use of block number which everyone agrees on for time.

--- a/primitives/chocolate-projects/Cargo.toml
+++ b/primitives/chocolate-projects/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "chocolate-projects"
+version = "0.1.0"
+edition = "2021"
+description = "Primitives crate for chocolate projects"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/primitives/chocolate-projects/Cargo.toml
+++ b/primitives/chocolate-projects/Cargo.toml
@@ -5,5 +5,93 @@ edition = "2021"
 description = "Primitives crate for chocolate projects"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[package.metadata.docs.rs]
+targets = ['x86_64-unknown-linux-gnu']
+# ----------------_ dup
+[dev-dependencies.serde]
+version = '1.0.126'
 
-[dependencies]
+[dev-dependencies.sp-core]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'monthly-2021-08'
+version = '4.0.0-dev'
+
+[dev-dependencies.sp-io]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'monthly-2021-08'
+version = '4.0.0-dev'
+
+[dev-dependencies.sp-runtime]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'monthly-2021-08'
+version = '4.0.0-dev'
+
+[dependencies.codec]
+default-features = false
+features = ['derive']
+package = 'parity-scale-codec'
+version = '2.0.0'
+
+
+[dependencies.sp-std]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'monthly-2021-08'
+version = '4.0.0-dev'
+
+[dependencies.frame-benchmarking]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+optional = true
+tag = 'monthly-2021-08'
+version = '4.0.0-dev'
+
+[dependencies.frame-support]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'monthly-2021-08'
+version = '4.0.0-dev'
+
+[dependencies.frame-system]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'monthly-2021-08'
+version = '4.0.0-dev'
+
+# Added pallets
+[dependencies.pallet-treasury]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'monthly-2021-08'
+version = '4.0.0-dev'
+# Added pallets
+[dependencies.pallet-balances]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'monthly-2021-08'
+version = '4.0.0-dev'
+# added pallets - duplicate with dev serde
+[dependencies.serde]
+version = "1.0.126"
+optional = true
+features = ['derive']
+# # added dep
+
+[features]
+default = ['std']
+# or here?
+runtime-benchmarks = ['frame-benchmarking']
+std = [
+    'serde',
+    'codec/std',
+    'sp-std/std',
+    'frame-support/std',
+    'frame-system/std',
+    'pallet-treasury/std',
+    'pallet-balances/std',
+    'frame-benchmarking/std',
+]
+try-runtime = ['frame-support/try-runtime']

--- a/primitives/chocolate-projects/src/lib.rs
+++ b/primitives/chocolate-projects/src/lib.rs
@@ -1,0 +1,8 @@
+#[cfg(test)]
+mod tests {
+	#[test]
+	fn it_works() {
+		let result = 2 + 2;
+		assert_eq!(result, 4);
+	}
+}

--- a/primitives/chocolate-projects/src/lib.rs
+++ b/primitives/chocolate-projects/src/lib.rs
@@ -1,8 +1,3 @@
-#[cfg(test)]
-mod tests {
-	#[test]
-	fn it_works() {
-		let result = 2 + 2;
-		assert_eq!(result, 4);
-	}
-}
+#![cfg_attr(not(feature = "std"), no_std)]
+
+

--- a/primitives/chocolate-projects/src/lib.rs
+++ b/primitives/chocolate-projects/src/lib.rs
@@ -1,3 +1,115 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use frame_support::dispatch::DispatchResult;
+use frame_system::Config;
+use sp_std::vec::Vec;
+/// type alias for text
+pub type TextAl = Vec<u8>;
+/// A simple u32
+pub type ProjectID = u32;
+/// Index for reviews , use to link to project
+pub type ReviewID = u64;
+use codec::{Decode, Encode};
+#[derive(Encode, Decode, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "std", derive(Debug))]
+pub struct Review<UserID> {
+	pub proposal_status: ProposalStatus,
+	pub user_id: UserID,
+	pub content: Vec<u8>,
+	pub project_id: ProjectID,
+}
 
+/// The metadata of a project.
+type MetaData = Vec<u8>;
+
+#[cfg(feature = "std")]
+pub use serde::{Deserialize, Serialize};
+
+/// The status of the proposal
+#[derive(Encode, Decode, Clone, PartialEq)]
+#[cfg_attr(feature = "std", derive(Debug))]
+#[cfg_attr(feature = "std", derive(Deserialize, Serialize))]
+pub enum Status {
+	///Proposal created
+	Proposed,
+	/// Proposal accepted
+	Accepted,
+	/// Proposal rejected
+	Rejected,
+}
+/// Reason for the current status - Required for rejected proposal.
+#[derive(Encode, Decode, Clone, PartialEq)]
+#[cfg_attr(feature = "std", derive(Debug))]
+#[cfg_attr(feature = "std", derive(Deserialize, Serialize))]
+pub enum Reason {
+	/// Custom reason to encapsulate further things like marketCap and other details
+	Other(Vec<u8>),
+	/// Negative lenient - base conditions for project missing or review lacking detail
+	InsufficientMetaData,
+	/// Negative harsh, project or review is malicious
+	Malicious,
+	/// Positive neutral, covers rank up to accepted.
+	PassedRequirements,
+}
+/// The status of a proposal sent to the council from here.
+#[derive(Encode, Decode, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "std", derive(Debug))]
+pub struct ProposalStatus {
+	pub status: Status,
+	pub reason: Reason,
+}
+/// Default status - storage req
+impl Default for Status {
+	fn default() -> Self {
+		Status::Proposed
+	}
+}
+/// Default reason - storage req
+impl Default for Reason {
+	fn default() -> Self {
+		Reason::PassedRequirements
+	}
+}
+/// The project structure.
+#[derive(Encode, Decode, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "std", derive(Debug))]
+pub struct Project<UserID, Balance> {
+	/// The owner of the project
+	pub owner_id: UserID,
+	/// A list of the project's reviewers for validation. (default: 0)
+	pub reviewers: Option<Vec<UserID>>,
+	/// A list of the project's reviews - Vec (default : none)
+	pub reviews: Option<Vec<ReviewID>>,
+	/// A bool that allows for simple allocation of the unique chocolate badge. NFT?? (default: false)
+	badge: Option<bool>,
+	/// Project metadata - req - default some .
+	metadata: MetaData,
+	/// the status of the project's proposal in the council - default proposed.
+	pub proposal_status: ProposalStatus,
+	/// A reward value for the project ---------_switch to idea of named reserve hash - (default: Reward).
+	pub reward: Balance,
+}
+// ------------------------------------------------------------^edit
+impl<UserID, Balance> Project<UserID, Balance> {
+	/// (Trim) Set useful defaults.
+	pub fn new(
+		owner_id: UserID,
+		reviewers: Option<Vec<UserID>>,
+		reviews: Option<Vec<ReviewID>>,
+		badge: Option<bool>,
+		metadata: MetaData,
+		proposal_status: ProposalStatus,
+		reward: Balance,
+	) -> Self {
+		Project { owner_id, reviewers, reviews, badge, metadata, proposal_status, reward }
+	}
+}
+/// A trait that allows project to:
+/// - reserve some token for rewarding its reviewers.
+pub trait ProjectIO<T: Config> {
+	type UserID;
+	type Balance;
+
+	fn can_reward(project: &Project<Self::UserID, Self::Balance>) -> bool;
+	fn reserve_reward(project: &mut Project<Self::UserID, Self::Balance>) -> DispatchResult;
+}

--- a/primitives/chocolate-users/Cargo.toml
+++ b/primitives/chocolate-users/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "chocolate-users"
+version = "0.1.0"
+edition = "2021"
+description = "Primitives crate for chocolate users"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/primitives/chocolate-users/Cargo.toml
+++ b/primitives/chocolate-users/Cargo.toml
@@ -6,4 +6,70 @@ description = "Primitives crate for chocolate users"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dependencies]
+[package.metadata.docs.rs]
+targets = ['x86_64-unknown-linux-gnu']
+
+[dev-dependencies.serde]
+version = '1.0.126'
+
+[dev-dependencies.sp-core]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'monthly-2021-08'
+version = '4.0.0-dev'
+
+[dev-dependencies.sp-io]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'monthly-2021-08'
+version = '4.0.0-dev'
+
+[dev-dependencies.sp-runtime]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'monthly-2021-08'
+version = '4.0.0-dev'
+
+[dependencies.codec]
+default-features = false
+features = ['derive']
+package = 'parity-scale-codec'
+version = '2.0.0'
+
+[dependencies.sp-std]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'monthly-2021-08'
+version = '4.0.0-dev'
+
+[dependencies.frame-benchmarking]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+optional = true
+tag = 'monthly-2021-08'
+version = '4.0.0-dev'
+
+[dependencies.frame-support]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'monthly-2021-08'
+version = '4.0.0-dev'
+
+[dependencies.frame-system]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'monthly-2021-08'
+version = '4.0.0-dev'
+
+[features]
+default = ['std']
+# is benchmarking necessary here?
+runtime-benchmarks = ['frame-benchmarking']
+std = [
+    'codec/std',
+    'sp-std/std',
+    'frame-support/std',
+    'frame-system/std',
+    'frame-benchmarking/std',
+]
+try-runtime = ['frame-support/try-runtime']

--- a/primitives/chocolate-users/src/lib.rs
+++ b/primitives/chocolate-users/src/lib.rs
@@ -1,0 +1,8 @@
+#[cfg(test)]
+mod tests {
+	#[test]
+	fn it_works() {
+		let result = 2 + 2;
+		assert_eq!(result, 4);
+	}
+}

--- a/primitives/chocolate-users/src/lib.rs
+++ b/primitives/chocolate-users/src/lib.rs
@@ -1,2 +1,21 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use codec::{Decode, Encode};
+use frame_support::dispatch::DispatchResult;
+use frame_system::Config;
+use sp_std::vec::Vec;
+
+#[derive(Encode, Decode, Default, Clone)]
+pub struct User {
+	pub rank_points: u32,
+	pub project_id: Option<u32>,
+}
+
+/// UserIO trait for CRUD on users store
+pub trait UserIO<T: Config> {
+	fn get_user_by_id(id: &T::AccountId) -> Option<User>;
+	fn check_owns_project(id: &T::AccountId) -> bool;
+	fn check_user_exists(id: &T::AccountId) -> bool;
+	fn set_user(id: &T::AccountId, user: User) -> DispatchResult;
+	fn update_user(id: &T::AccountId, user: User) -> DispatchResult;
+}

--- a/primitives/chocolate-users/src/lib.rs
+++ b/primitives/chocolate-users/src/lib.rs
@@ -1,8 +1,2 @@
-#[cfg(test)]
-mod tests {
-	#[test]
-	fn it_works() {
-		let result = 2 + 2;
-		assert_eq!(result, 4);
-	}
-}
+#![cfg_attr(not(feature = "std"), no_std)]
+

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -14,7 +14,8 @@ targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies.chocolate-node-constants]
 path = '../primitives/chocolate-node-constants'
-version = '0.1.0'
+version = "0.1.1"
+default-features = false
 
 [dependencies.pallet-chocolate]
 default-features = false
@@ -264,6 +265,7 @@ std = [
     "pallet-elections-phragmen/std",
     # Added custom, include for refactor
     # "node-primitives/std",
+    "chocolate-node-constants/std",
     'pallet-timestamp/std',
     'pallet-transaction-payment-rpc-runtime-api/std',
     'pallet-transaction-payment/std',

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -12,6 +12,10 @@ version = '3.0.0-monthly-2021-08'
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']
 
+[dependencies.chocolate-node-constants]
+path = '../primitives/chocolate-node-constants'
+version = '0.1.0'
+
 [dependencies.pallet-chocolate]
 default-features = false
 path = '../pallets/chocolate'

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -331,6 +331,9 @@ impl pallet_sudo::Config for Runtime {
 	type Call = Call;
 }
 
+parameter_types! {
+	pub const RewardCap: Balance = 50 * CHOC; // define choc well.
+}
 /// Configure the pallet-chocolate in pallets/chocolate.
 impl pallet_chocolate::Config for Runtime {
 	type Event = Event;
@@ -340,6 +343,9 @@ impl pallet_chocolate::Config for Runtime {
 		pallet_collective::EnsureProportionAtLeast<_3, _5, AccountId, CouncilCollective>,
 	>;
 	type Currency = Balances;
+	type TreasuryOutlet = Treasury; 
+	type RewardCap = RewardCap;
+	
 }
 /// Configure the pallet-users in pallets/users.
 impl pallet_users::Config for Runtime {
@@ -441,10 +447,6 @@ impl pallet_treasury::Config for Runtime {
 	type SpendPeriod = SpendPeriod;
 	type Burn = Burn;
 	type BurnDestination = ();
-	// Initially implemented for Bounties pallet. Use this to make the treasury spend funds for reviews
-	// say if the treasury still has funds, reward the review, otherwise return their payments. Also use subaccounts for staking hehe?
-	// set it up so that if the user is not rewarded, we simply give them an opportunity to take it up with the treasury later.
-	// set up treasury in a way that we always have enough to cater for bonuses of everyone on the system in an interest manner.
 	type SpendFunds = ();
 	type WeightInfo = pallet_treasury::weights::SubstrateWeight<Runtime>;
 	type MaxApprovals = MaxApprovals;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -114,7 +114,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 // Note: This could be later moved into a constants file - Separating time and currency, and importing primitives from node-primitives. Or here.
 
 pub const fn deposit(items: u32, bytes: u32) -> Balance {
-	items as Balance * 15 * CENTICHOC + (bytes as Balance) * 6 * CENTICHOC
+	items as Balance * 15 * CHOC + (bytes as Balance) * 6 * CHOC
 }
 
 type NegativeImbalance = <Balances as Currency<AccountId>>::NegativeImbalance;
@@ -307,7 +307,7 @@ impl pallet_sudo::Config for Runtime {
 }
 
 parameter_types! {
-	pub const RewardCap: Balance = 50 * CHOC; // define choc well.
+	pub const RewardCap: Balance = 50 * HECTOCHOC;
 }
 /// Configure the pallet-chocolate in pallets/chocolate.
 impl pallet_chocolate::Config for Runtime {
@@ -348,7 +348,7 @@ impl pallet_collective::Config<CouncilCollective> for Runtime {
 
 // council election method configuration
 parameter_types! {
-	pub const CandidacyBond: Balance = 10 * CHOC;
+	pub const CandidacyBond: Balance = 10 * HECTOCHOC;
 	// 1 storage item created, key size is 32 bytes, value size is 16+16.
 	pub const VotingBondBase: Balance = deposit(1, 64);
 	// additional data per vote is 32 bytes (account id).
@@ -385,20 +385,20 @@ impl pallet_elections_phragmen::Config for Runtime {
 // treasury config. To-Do: Impl SpendFund trait on reviews and give treasury money on start.
 parameter_types! {
 	pub const ProposalBond: Permill = Permill::from_percent(5);
-	pub const ProposalBondMinimum: Balance = 1 * CHOC;
+	pub const ProposalBondMinimum: Balance = 1 * HECTOCHOC;
 	pub const SpendPeriod: BlockNumber = 1 * DAYS;
 	pub const Burn: Permill = Permill::from_percent(50);
 	pub const TipCountdown: BlockNumber = 1 * DAYS;
 	pub const TipFindersFee: Percent = Percent::from_percent(20);
-	pub const TipReportDepositBase: Balance = 1 * CHOC;
-	pub const DataDepositPerByte: Balance = 1 * CENTICHOC;
-	pub const BountyDepositBase: Balance = 1 * CHOC;
+	pub const TipReportDepositBase: Balance = 1 * HECTOCHOC;
+	pub const DataDepositPerByte: Balance = 1 * CHOC;
+	pub const BountyDepositBase: Balance = 1 * HECTOCHOC;
 	pub const BountyDepositPayoutDelay: BlockNumber = 1 * DAYS;
 	pub const TreasuryPalletId: PalletId = PalletId(*b"py/trsry");
 	pub const BountyUpdatePeriod: BlockNumber = 14 * DAYS;
 	pub const MaximumReasonLength: u32 = 16384;
 	pub const BountyCuratorDeposit: Permill = Permill::from_percent(50);
-	pub const BountyValueMinimum: Balance = 5 * CHOC;
+	pub const BountyValueMinimum: Balance = 5 * HECTOCHOC;
 	pub const MaxApprovals: u32 = 100;
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -54,8 +54,7 @@ pub use sp_runtime::{Perbill, Percent, Permill};
 pub use pallet_chocolate;
 /// Import the users pallet
 pub use pallet_users;
-/// An index to a block.
-pub type BlockNumber = u32;
+pub use chocolate_node_constants::*;
 
 /// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
 pub type Signature = MultiSignature;
@@ -63,9 +62,6 @@ pub type Signature = MultiSignature;
 /// Some way of identifying an account on the chain. We intentionally make it equivalent
 /// to the public key of our transaction signing scheme.
 pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
-
-/// Balance of an account.
-pub type Balance = u128;
 
 /// Index of a transaction in the chain.
 pub type Index = u32;
@@ -117,27 +113,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 
 // Note: This could be later moved into a constants file - Separating time and currency, and importing primitives from node-primitives. Or here.
 
-/// This determines the average expected block time that we are targeting.
-/// Blocks will be produced at a minimum duration defined by `SLOT_DURATION`.
-/// `SLOT_DURATION` is picked up by `pallet_timestamp` which is in turn picked
-/// up by `pallet_aura` to implement `fn slot_duration()`.
-///
-/// Change this to adjust the block time.
-pub const MILLISECS_PER_BLOCK: u64 = 6000;
 
-// NOTE: Currently it is not possible to change the slot duration after the chain has started.
-//       Attempting to do so will brick block production.
-pub const SLOT_DURATION: u64 = MILLISECS_PER_BLOCK;
-
-// Time is measured by number of blocks.
-pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);
-pub const HOURS: BlockNumber = MINUTES * 60;
-pub const DAYS: BlockNumber = HOURS * 24;
-
-// This specifies currency things. Currently set to recurse on our currency. CHANGE FOR DEFI
-pub const MILLICENTICHOC: Balance = 1_000_000_000;
-pub const CENTICHOC: Balance = 1_000 * MILLICENTICHOC;
-pub const CHOC: Balance = 100 * CENTICHOC;
 pub const fn deposit(items: u32, bytes: u32) -> Balance {
 	items as Balance * 15 * CENTICHOC + (bytes as Balance) * 6 * CENTICHOC
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -50,11 +50,11 @@ use pallet_transaction_payment::CurrencyAdapter;
 pub use sp_runtime::BuildStorage;
 pub use sp_runtime::{Perbill, Percent, Permill};
 
+pub use chocolate_node_constants::*;
 /// Import the chocolate pallet.
 pub use pallet_chocolate;
 /// Import the users pallet
 pub use pallet_users;
-pub use chocolate_node_constants::*;
 
 /// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
 pub type Signature = MultiSignature;
@@ -112,7 +112,6 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 };
 
 // Note: This could be later moved into a constants file - Separating time and currency, and importing primitives from node-primitives. Or here.
-
 
 pub const fn deposit(items: u32, bytes: u32) -> Balance {
 	items as Balance * 15 * CENTICHOC + (bytes as Balance) * 6 * CENTICHOC
@@ -319,9 +318,9 @@ impl pallet_chocolate::Config for Runtime {
 		pallet_collective::EnsureProportionAtLeast<_3, _5, AccountId, CouncilCollective>,
 	>;
 	type Currency = Balances;
-	type TreasuryOutlet = Treasury; 
+	type TreasuryOutlet = Treasury;
 	type RewardCap = RewardCap;
-	
+	type UsersOutlet = UsersModule;
 }
 /// Configure the pallet-users in pallets/users.
 impl pallet_users::Config for Runtime {


### PR DESCRIPTION
**PR**

* Split traits and types into crates under primitives 
  * (constants for runtime constants and projects for chocolate-pallet and users for users-pallet)
* Added proper units for manipulating balances  (based on si-units)
* Exposed mint feature to the council.
* Chocolate pallet coupled with Users pallet via UserIO for manipulation and to provide access to points
* All ready for collateralisation.

**[Next...]**: Collateralisation features and modifications to `create_review`, `create_project` based on that.
* new extrinsic to approve review and end collateralisation cycle
* New proposal state to account for slashed reviews and allow update of review by the user (to bring things back to init state for recheck).
* Rewards setup and fixed-point arithmetic crate import (Division)

_Merge after step1_